### PR TITLE
Make search work with symlinks, and make file indexing faster.

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	_ "github.com/nektro/andesite/statik"
 )
 
-
 func main() {
 	Log("Initializing Andesite...")
 


### PR DESCRIPTION
This changes the use of ``path/filepath``'s ``Walk`` to ``github.com/karrick/godirwalk``, which is faster, and supports symlinks.

Tested on Linux -- should work the same on other OSs just fine.