### PR TITLE
Fix symlink usage causing the program to crash and burn

### DIFF
--- a/pkg/fsdb/fsdb.go
+++ b/pkg/fsdb/fsdb.go
@@ -35,7 +35,7 @@ func Init(mp map[string]string, rt string) {
 				realpath, _ := filepath.EvalSymlinks(osPathname)
 				if realpath == "" {
 					util.LogError("fsdb:", rt+":", "symlink", osPathname, "is pointing to a non-existing file")
-					return nil
+					return godirwalk.SkipThis
 				}
 				s, err := os.Lstat(realpath)
 				if err != nil {

--- a/pkg/fsdb/fsdb.go
+++ b/pkg/fsdb/fsdb.go
@@ -33,7 +33,11 @@ func Init(mp map[string]string, rt string) {
 			}
 			if s.Mode()&os.ModeSymlink != 0 {
 				realpath, _ := filepath.EvalSymlinks(osPathname)
-				s, _ = os.Lstat(realpath)
+				s, err := os.Lstat(realpath)
+				if err != nil {
+					util.LogError("fsdb:", rt+":", err)
+					return nil
+				}
 				if s.IsDir() {
 					return nil
 				}

--- a/pkg/fsdb/fsdb.go
+++ b/pkg/fsdb/fsdb.go
@@ -33,6 +33,10 @@ func Init(mp map[string]string, rt string) {
 			}
 			if s.Mode()&os.ModeSymlink != 0 {
 				realpath, _ := filepath.EvalSymlinks(osPathname)
+				if realpath == "" {
+					util.LogError("fsdb:", rt+":", "symlink", osPathname, "is pointing to a non-existing file")
+					return nil
+				}
 				s, err := os.Lstat(realpath)
 				if err != nil {
 					util.LogError("fsdb:", rt+":", err)

--- a/pkg/fsdb/fsdb.go
+++ b/pkg/fsdb/fsdb.go
@@ -32,8 +32,8 @@ func Init(mp map[string]string, rt string) {
 				return nil
 			}
 			if s.Mode()&os.ModeSymlink != 0 {
-				realpath, _ := os.Readlink(osPathname)
-				s, _ = os.Lstat(filepath.Dir(osPathname) + "/" + realpath)
+				realpath, _ := filepath.EvalSymlinks(osPathname)
+				s, _ = os.Lstat(realpath)
 				if s.IsDir() {
 					return nil
 				}

--- a/pkg/handler/listing.go
+++ b/pkg/handler/listing.go
@@ -98,8 +98,7 @@ func HandleDirectoryListing(getAccess func(http.ResponseWriter, *http.Request) (
 				return
 			}
 
-			data := make([]map[string]interface{}, len(files))
-			gi := 0
+			data := make([]map[string]interface{}, 0)
 			for i := 0; i < len(files); i++ {
 				name := files[i].Name()
 				a := ""
@@ -107,9 +106,13 @@ func HandleDirectoryListing(getAccess func(http.ResponseWriter, *http.Request) (
 					a = name + "/"
 				} else if files[i].Mode()&os.ModeSymlink != 0 {
 					// resolve link, then do this again
-					realpath, _ := os.Readlink(fileRoot + qpath + files[i].Name())
+					realpath, _ := filepath.EvalSymlinks(fileRoot + qpath + files[i].Name())
+					if realpath == "" {
+						util.LogError("symlink", fileRoot + qpath + files[i].Name(), "is pointing to a non-existing file")
+						continue
+					}
+					
 					symfile, err := os.Lstat(realpath)
-
 					if err != nil {
 						util.LogError(err)
 						continue
@@ -129,15 +132,14 @@ func HandleDirectoryListing(getAccess func(http.ResponseWriter, *http.Request) (
 				if len(ext) == 0 {
 					ext = ".asc"
 				}
-				data[gi] = map[string]interface{}{
+				data = append(data, map[string]interface{}{
 					"name":    a,
 					"size":    util.ByteCountIEC(files[i].Size()),
 					"mod":     files[i].ModTime().UTC().String()[:19],
 					"ext":     ext[1:],
 					"mod_raw": strconv.FormatInt(files[i].ModTime().UTC().Unix(), 10),
 					"is_file": !files[i].IsDir(),
-				}
-				gi++
+				})
 			}
 			pth := r.URL.Path[len(idata.Config.HTTPBase)-1:]
 			printer := message.NewPrinter(language.English)


### PR DESCRIPTION
Using symbolic links makes Andesite act in various weird ways, they can either break the file listing, break file type detection, or crash the program entirely at startup with FsDB checks breaking due to lack of error handling.

This set of commits should entirely fix these problems making symlinks work as seamless as actual files and folders.

A full set of changes and what they do are in the extended description of each commit.